### PR TITLE
deprecate CYCLOPE_STATIC_URL in favour of django.contrib.staticfiles app

### DIFF
--- a/cyclope/admin.py
+++ b/cyclope/admin.py
@@ -74,8 +74,8 @@ class BaseContentAdmin(admin.ModelAdmin):
 
     class Media:
         js = (
-            cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_PATH,
-            #cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_MIGRATE_PATH, TODO
+            cyc_settings.CYCLOPE_JQUERY_PATH,
+            #cyc_settings.CYCLOPE_JQUERY_MIGRATE_PATH, TODO
         )
 
     def response_change(self, request, obj):
@@ -171,9 +171,7 @@ class MenuItemAdmin(TreeEditor, PermanentFilterMixin):
     )
 
     class Media:
-        js = (
-            cyc_settings.CYCLOPE_STATIC_URL + 'js/reuse_django_jquery.js',
-        )
+        js = ( 'js/reuse_django_jquery.js',)
 
     def changelist_view(self, request, extra_context=None):
         self.do_permanent_filters(request)
@@ -206,7 +204,7 @@ class LayoutAdmin(admin.ModelAdmin):
         return super(LayoutAdmin, self).change_view(request, object_id, form_url, extra_context)
         
     class Media:
-        js = (cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_PATH,)
+        js = (cyc_settings.CYCLOPE_JQUERY_PATH,)
 
 admin.site.register(Layout, LayoutAdmin)
 
@@ -260,7 +258,7 @@ class DesignSettingsAdmin(SingletonAdminMixin):
     )
 
     class Media:
-        js = (cyc_settings.CYCLOPE_STATIC_URL + "js/jscolor/jscolor.js",)
+        js = ("js/jscolor/jscolor.js",)
 
 admin.site.register(DesignSettings, DesignSettingsAdmin)
 

--- a/cyclope/apps/articles/admin.py
+++ b/cyclope/apps/articles/admin.py
@@ -75,8 +75,8 @@ class ArticleAdmin(CollectibleAdmin, BaseContentAdmin):
 
     class Media:
         css = {
-            'all' : (cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_UI_CSS_PATH,
-                     cyc_settings.CYCLOPE_STATIC_URL + 'css/media_widget.css')
+            'all' : (cyc_settings.CYCLOPE_JQUERY_UI_CSS_PATH,
+                    'css/media_widget.css')
         }
 
 admin.site.register(Article, ArticleAdmin)

--- a/cyclope/apps/articles/templates/admin/articles/article/change_form.html
+++ b/cyclope/apps/articles/templates/admin/articles/article/change_form.html
@@ -1,12 +1,13 @@
 {% extends "admin/base_content_change_form.html" %}
+{% load staticfiles %}
 {% block extrahead %}
     {% url 'admin:jsi18n' as jsi18nurl %}
     <script type="text/javascript" src="{{ jsi18nurl|default:"../../../jsi18n/" }}"></script>
     {{ media }}
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/jquery.chainedSelect.js"></script>
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/less.min.js"></script>
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}{{ CYCLOPE_JQUERY_UI_PATH }}"></script>
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/cyclope_media_widget.js"></script>
+    <script type="text/javascript" src="{% static 'js/jquery.chainedSelect.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/less.min.js' %}"></script>
+    <script type="text/javascript" src="{% static CYCLOPE_JQUERY_UI_PATH %}"></script>
+    <script type="text/javascript" src="{% static 'js/cyclope_media_widget.js' %}"></script>
 {% endblock %}
 {% block content %}
 	{{ block.super }}

--- a/cyclope/apps/contacts/templates/contacts/contact_teaser.html
+++ b/cyclope/apps/contacts/templates/contacts/contact_teaser.html
@@ -11,7 +11,7 @@
     {% else %}
         <div class="media-left">
             <a href="#">
-		    <img class="photo img-circle" src="{% static 'cyclope/images/img-author-not-available.png' %}" alt="Image not available" />
+		    <img class="photo img-circle" src="{% static 'images/img-author-not-available.png' %}" alt="Image not available" />
             </a>
         </div>
     {% endif %}  

--- a/cyclope/apps/dynamicforms/templates/admin/forms/change_form.html
+++ b/cyclope/apps/dynamicforms/templates/admin/forms/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_form.html" %}
 
-{% load i18n %}
+{% load i18n staticfiles %}
 {% load url from future %}
 
 {% block object-tools %}
@@ -23,6 +23,6 @@
 
 {% block extrahead %}
     {{ block.super }}
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}{{ CYCLOPE_JQUERY_UI_PATH }}"></script>
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/drag_drop.js"></script>
+    <script type="text/javascript" src="{% static CYCLOPE_JQUERY_UI_PATH %}"></script>
+    <script type="text/javascript" src="{% static 'js/drag_drop.js' %}"></script>
 {% endblock %}

--- a/cyclope/apps/media_widget/templates/media_widget/media_widget.html
+++ b/cyclope/apps/media_widget/templates/media_widget/media_widget.html
@@ -1,10 +1,10 @@
 {% load fb_versions staticfiles %}
 <head>
     <!--styles-->
-    <link href="{{CYCLOPE_STATIC_URL}}css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
     <!--scripts-->
-    <script type="text/javascript" src="{{CYCLOPE_STATIC_URL}}{{ CYCLOPE_JQUERY_PATH }}"></script>
-    <script type="text/javascript" src="{{CYCLOPE_STATIC_URL}}js/bootstrap/bootstrap.min.js"></script>
+    <script type="text/javascript" src="{% static CYCLOPE_JQUERY_PATH %}"></script>
+    <script type="text/javascript" src="{% static 'js/bootstrap/bootstrap.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'media_widget/media_widget.js' %}"></script>
     <script type="text/javascript">
     $(function(){ // nRows input

--- a/cyclope/apps/media_widget/templates/media_widget/pictures_widget.html
+++ b/cyclope/apps/media_widget/templates/media_widget/pictures_widget.html
@@ -1,10 +1,10 @@
 {% load staticfiles %}
 <head>
     <!--styles-->
-    <link href="{{CYCLOPE_STATIC_URL}}css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
     <!--scripts-->
-    <script type="text/javascript" src="{{CYCLOPE_STATIC_URL}}{{ CYCLOPE_JQUERY_PATH }}"></script>
-    <script type="text/javascript" src="{{CYCLOPE_STATIC_URL}}js/bootstrap/bootstrap.min.js"></script>
+    <script type="text/javascript" src="{% static CYCLOPE_JQUERY_PATH %}"></script>
+    <script type="text/javascript" src="{% static 'js/bootstrap/bootstrap.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'media_widget/pictures_widget.js' %}"></script>
     <script type="text/javascript">
     {% if refresh_widget %}

--- a/cyclope/apps/medialibrary/templates/medialibrary/media_player.html
+++ b/cyclope/apps/medialibrary/templates/medialibrary/media_player.html
@@ -1,9 +1,9 @@
-{% load i18n %}
+{% load i18n staticfiles %}
 
 {% block extra_head %}
-<script src="{{ CYCLOPE_STATIC_URL }}mediaelement/mediaelement-and-player.min.js"></script>
-<link rel="stylesheet" href="{{ CYCLOPE_STATIC_URL }}mediaelement/mediaelementplayer.min.css" type="text/css" />
-<link rel="stylesheet" href="{{ CYCLOPE_STATIC_URL }}mediaelement/mejs-skins.css" type="text/css" />
+<script src="{% static 'mediaelement/mediaelement-and-player.min.js' %}"></script>
+<link rel="stylesheet" href="{% static 'mediaelement/mediaelementplayer.min.css' %}" type="text/css" />
+<link rel="stylesheet" href="{% static 'mediaelement/mejs-skins.css'" type="text/css" />
 <script type='text/javascript'>
 // Here we are loading the media player for all media in the page.
 // We are using an indirect method to prevent multiple loading
@@ -53,8 +53,8 @@ var media_loaded = media_loaded || loadMedia();
   {% elif file_type == 'ogv' or file_type == 'flv' or file_type == 'mp4' or file_type == 'webm' %}
     <video width="{{ player_video_width|default:480 }}" height="{{ player_video_height|default:360 }}"  controls="controls" preload="none">
       <source src="{{ current_object.media_file }}" {% if file_type == 'ogv' %}type="video/ogg"{% else %}type="video/{{ file_type }}"{% endif %} />
-      <object width="{{ player_video_width|default:480 }}" height="{{ player_video_height|default:360 }}"  type="application/x-shockwave-flash" data="{{ CYCLOPE_STATIC_URL }}player/flashmediaelement.swf">
-        <param name="movie" value="{{ CYCLOPE_STATIC_URL }}player/flashmediaelement.swf" />
+      <object width="{{ player_video_width|default:480 }}" height="{{ player_video_height|default:360 }}"  type="application/x-shockwave-flash" data="{% static 'player/flashmediaelement.swf' %}">
+        <param name="movie" value="{% static 'player/flashmediaelement.swf' %}" />
         <param name="flashvars" value="controls=true&file={{ current_object.media_file }}" />
       </object>
     </video>

--- a/cyclope/apps/polls/admin.py
+++ b/cyclope/apps/polls/admin.py
@@ -55,9 +55,9 @@ class PollAdmin(admin.ModelAdmin):
     class Media:
         # This js is needed because drag&drop will be used
         js = (
-            cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_PATH,
-            #cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_MIGRATE_PATH, TODO
-            cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_UI_PATH,
+            cyc_settings.CYCLOPE_JQUERY_PATH,
+            #cyc_settings.CYCLOPE_JQUERY_MIGRATE_PATH, TODO
+            cyc_settings.CYCLOPE_JQUERY_UI_PATH,
         )
 
 admin.site.register(Question, QuestionAdmin)

--- a/cyclope/apps/polls/templates/admin/polls/change_form.html
+++ b/cyclope/apps/polls/templates/admin/polls/change_form.html
@@ -1,5 +1,5 @@
 {% extends 'admin/change_form.html' %}
 {% load staticfiles %}
 {% block after_related_objects %}
-    <script type="text/javascript" src="{% static 'cyclope/js/drag_drop.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/drag_drop.js' %}"></script>
 {% endblock %}

--- a/cyclope/bin/cyclopeproject
+++ b/cyclope/bin/cyclopeproject
@@ -67,20 +67,6 @@ class Command(TemplateCommand):
 
         super(Command, self).handle('project', project_name, target, **options)
 
-        # Create media
-        import markitup
-        import admin_tools
-        import filebrowser
-        import mptt_tree_editor
-        media = (
-            ("admin", os.path.join(django.__path__[0], "contrib", "admin", "static", "admin")),
-            ("markitup", os.path.join(markitup.__path__[0], "static", "markitup")),
-            ("admin_tools", os.path.join(admin_tools.__path__[0], "media", "admin_tools")), # esta app es la que no esta conforme a static?
-            ("filebrowser", os.path.join(filebrowser.__path__[0], "static", "filebrowser")),
-            ("cyclope", os.path.join(cyclope.__path__[0], "static")),
-            ("mptt_tree_editor", os.path.join(mptt_tree_editor.__path__[0], "static", "mptt_tree_editor")),
-        )
-
         directory = options.get("directory")
         top_dir = os.path.join(directory, project_name)
         #/media
@@ -89,8 +75,6 @@ class Command(TemplateCommand):
         #/static
         static_dir = os.path.join(top_dir, "static")
         os.mkdir(static_dir)
-        for name, path in media:
-            os.symlink(path, os.path.join(static_dir, name))
 
         # FIXME: this should not be here
         # Create db

--- a/cyclope/core/collections/admin.py
+++ b/cyclope/core/collections/admin.py
@@ -116,9 +116,7 @@ class CategoryAdmin(TreeEditor, PermanentFilterMixin):
         return super(CategoryAdmin, self).changelist_view(request, extra_context)
 
     class Media:
-        js = (
-            cyc_settings.CYCLOPE_STATIC_URL + 'js/reuse_django_jquery.js',
-        )
+        js = ('js/reuse_django_jquery.js',)
 
 admin.site.register(Category, CategoryAdmin)
 
@@ -255,10 +253,10 @@ class CategorizationAdmin(admin.ModelAdmin):
 
     class Media:
         js = (
-            cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_PATH,
-            #cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_MIGRATE_PATH, TODO
-            cyc_settings.CYCLOPE_STATIC_URL + cyc_settings.CYCLOPE_JQUERY_UI_PATH,
-            cyc_settings.CYCLOPE_STATIC_URL + 'js/drag_drop.js',
+            cyc_settings.CYCLOPE_JQUERY_PATH,
+            #cyc_settings.CYCLOPE_JQUERY_MIGRATE_PATH, TODO
+            cyc_settings.CYCLOPE_JQUERY_UI_PATH,
+            'js/drag_drop.js',
         )
 
 admin.site.register(Categorization, CategorizationAdmin)

--- a/cyclope/core/collections/templates/collections/category_slideshow.html
+++ b/cyclope/core/collections/templates/collections/category_slideshow.html
@@ -1,6 +1,6 @@
 {% extends host_template %}
 
-{% load i18n cyclope_utils fb_versions %}
+{% load i18n cyclope_utils fb_versions staticfiles %}
 
 {% block extra_head %}
 <script type="text/javascript" src="{% static 'js/jquery.jcarousel.min.js' %}"></script>

--- a/cyclope/core/collections/templates/collections/category_slideshow.html
+++ b/cyclope/core/collections/templates/collections/category_slideshow.html
@@ -3,7 +3,7 @@
 {% load i18n cyclope_utils fb_versions %}
 
 {% block extra_head %}
-<script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/jquery.jcarousel.min.js"></script>
+<script type="text/javascript" src="{% static 'js/jquery.jcarousel.min.js' %}"></script>
 <script type="text/javascript">
     // jCarousel documentation http://sorgalla.com/projects/jcarousel/
 

--- a/cyclope/default_settings.py
+++ b/cyclope/default_settings.py
@@ -235,7 +235,7 @@ AUTH_PROFILE_MODULE = "user_profiles.UserProfile"
 # admin-tools settings
 ADMIN_TOOLS_INDEX_DASHBOARD = 'cyclope.dashboard.CustomIndexDashboard'
 ADMIN_TOOLS_APP_INDEX_DASHBOARD = 'cyclope.dashboard.CustomAppIndexDashboard'
-ADMIN_TOOLS_THEMING_CSS = 'cyclope/css/admin_tools_theming.css'
+ADMIN_TOOLS_THEMING_CSS = 'css/admin_tools_theming.css'
 
 LOCALE_PATHS = (os.path.join(os.path.dirname(__file__), "locale_external"), )
 
@@ -270,8 +270,8 @@ ROSETTA_EXCLUDED_APPLICATIONS = (
     )
 
 # martkitup settings
-JQUERY_URL = 'cyclope/js/jquery-1.12.4.min.js' # TODO import it from settings.py
-MARKITUP_SET = 'cyclope/markitup/sets/textile'
+JQUERY_URL = 'js/jquery-1.12.4.min.js' # TODO import it from settings.py
+MARKITUP_SET = 'markitup/sets/textile'
 MARKITUP_FILTER = ('django.contrib.markup.templatetags.markup.textile', {})
 
 # crispy forms settings

--- a/cyclope/forms.py
+++ b/cyclope/forms.py
@@ -40,7 +40,7 @@ from cyclope.apps.related_admin import GenericFKWidget, GenericModelForm
 from cyclope.apps.related_admin import GenericModelChoiceField as GMCField
 from haystack.forms import ModelSearchForm
 import cyclope.settings as cyc_settings
-
+from django.conf import settings
 from django.forms.widgets import RadioFieldRenderer
 from django.forms import RadioSelect
 from django.utils.encoding import force_unicode
@@ -234,7 +234,7 @@ class DesignSettingsAdminForm(forms.ModelForm):
         class TableRadioFieldRenderer(RadioFieldRenderer):
             def render(self):
                 """Outputs a table for this set of radio fields."""
-                src = cyc_settings.CYCLOPE_STATIC_URL+u'images/theme-skins-thumbnail/{}.png'
+                src = settings.STATIC_URL+u'images/theme-skins-thumbnail/{}.png'
                 row = u'<tr><td>{}</td><td><image src="'+src+u'"/></td></tr>'
                 return mark_safe(u'<table class="radio-skin-tbl">\n%s\n</table>' % u'\n'.join([row.format(force_unicode(w),force_unicode(w.choice_value)) for w in self]))
         renderer = TableRadioFieldRenderer

--- a/cyclope/settings.py
+++ b/cyclope/settings.py
@@ -30,8 +30,6 @@ Attributes:
 
     CYCLOPE_PROJECT_PATH: path to the django project that will be serving Cyclope
     CYCLOPE_PREFIX: prefix for Cyclope URLs, defaults to 'cyclope/'
-    CYCLOPE_STATIC_URL: URL to Cyclope static files
-    CYCLOPE_STATIC_ROOT: defaults to cyclope/ folder of the project's STATIC_ROOT
 
   Automatic (based on database values):
 
@@ -61,10 +59,9 @@ from cyclope.core.frontend.sites import site
 
 CYCLOPE_PREFIX = getattr(settings, 'CYCLOPE_PREFIX', 'cyclope/')
 
-CYCLOPE_STATIC_URL = getattr(settings, 'CYCLOPE_STATIC_URL', '%scyclope/' % settings.STATIC_URL)
-CYCLOPE_STATIC_ROOT = getattr(settings, 'CYCLOPE_STATIC_ROOT', '%scyclope/' % settings.STATIC_ROOT)
-
 # For backwards compatibility only!
+CYCLOPE_STATIC_URL = getattr(settings, 'CYCLOPE_STATIC_URL', settings.STATIC_URL)
+CYCLOPE_STATIC_ROOT = getattr(settings, 'CYCLOPE_STATIC_ROOT', settings.STATIC_ROOT)
 CYCLOPE_MEDIA_URL =  CYCLOPE_STATIC_URL
 CYCLOPE_MEDIA_ROOT = CYCLOPE_STATIC_ROOT
 
@@ -143,7 +140,7 @@ def populate_from_site_settings(site_settings):
         CYCLOPE_THEME_MEDIA_URL = '%s%s/' % (
             settings.CYCLOPE_LOCAL_THEMES_MEDIA_PREFIX, CYCLOPE_CURRENT_THEME)
     else:
-        CYCLOPE_THEME_MEDIA_URL = '%sthemes/%s/' % (CYCLOPE_STATIC_URL,
+        CYCLOPE_THEME_MEDIA_URL = '%sthemes/%s/' % (settings.STATIC_URL,
                                                     CYCLOPE_CURRENT_THEME)
 
     CYCLOPE_THEME_PREFIX = 'cyclope/themes/%s/' % CYCLOPE_CURRENT_THEME

--- a/cyclope/templates/admin/base_content_change_form.html
+++ b/cyclope/templates/admin/base_content_change_form.html
@@ -3,7 +3,7 @@
 
 {% block extrastyle %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="{{ CYCLOPE_STATIC_URL }}css/tabbed_collections.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'css/tabbed_collections.css' %}" />
 {% endblock %}
 
 
@@ -176,7 +176,7 @@ jQuery(document).ready(function($){
 </script>
 
 {% if original.related_contents.count >= 0 %}
-    <script type="text/javascript" src="{% static 'cyclope/js/drag_drop.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/drag_drop.js' %}"></script>
 {% endif %}
 
 {% endblock %}

--- a/cyclope/templates/admin/base_site.html
+++ b/cyclope/templates/admin/base_site.html
@@ -1,6 +1,6 @@
 {% extends "admin/base.html" %}
-{% load i18n %}
-{% block extrastyle %}{% load adminmedia %}<link rel="icon" href="{{ CYCLOPE_STATIC_URL }}images/cyclope-icon.png" type="image/png">{% endblock %}
+{% load i18n staticfiles %}
+{% block extrastyle %}{% load adminmedia %}<link rel="icon" href="{% static 'images/cyclope-icon.png' %}" type="image/png">{% endblock %}
 {% block title %}{{ title }} | {% trans 'Cyclope site admin' %}{% endblock %}
 
 {% block branding %}

--- a/cyclope/templates/admin/change_form.html
+++ b/cyclope/templates/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_modify adminmedia admin_static %}
+{% load i18n admin_modify adminmedia staticfiles %}
 {% load url from future %}
 {% load admin_urls %}
 
@@ -8,15 +8,15 @@
 {% url 'admin:jsi18n' as jsi18nurl %}
 <script type="text/javascript" src="{{ jsi18nurl|default:"../../../jsi18n/" }}"></script>
 {{ media }}
-<script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/jquery.chainedSelect.js"></script>
-<script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/less.min.js"></script>
+<script type="text/javascript" src="{% static 'js/jquery.chainedSelect.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/less.min.js' %}"></script>
 {% endblock %}
 
 {% block extrastyle %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />
 {% if frontend_admin %}
-<link href="{{ CYCLOPE_STATIC_URL }}css/frontend_edit.css" rel="stylesheet" type="text/css"/>
+<link href="{% static 'css/frontend_edit.css' %}" rel="stylesheet" type="text/css"/>
 <link href="{{ CYCLOPE_THEME_MEDIA_URL }}css/frontend_edit.less" rel="stylesheet/less" type="text/css"/>
 {% endif %}
 {% endblock %}

--- a/cyclope/templates/admin/cyclope/layout/change_form.html
+++ b/cyclope/templates/admin/cyclope/layout/change_form.html
@@ -10,8 +10,8 @@
         var layout_data = {% layout_regions_data %};
     //]]>
     </script>
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}{{ CYCLOPE_JQUERY_UI_PATH }}"></script>
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL}}js/layouts.js"></script>
+    <script type="text/javascript" src="{% static CYCLOPE_JQUERY_UI_PATH %}"></script>
+    <script type="text/javascript" src="{% static 'js/layouts.js' %}"></script>
 {% endblock %}
 
 {% block after_related_objects %}
@@ -30,7 +30,7 @@
                     <li>
                         <h3>
                             <span>{{region.name}}</span>
-                            <a href="#" title="{% trans 'Add' %}" class="add_view_to_region" data-region="{{name}}"><img src="{{ CYCLOPE_STATIC_URL}}images/add-small.png"/></a>
+                            <a href="#" title="{% trans 'Add' %}" class="add_view_to_region" data-region="{{name}}"><img src="{% static 'images/add-small.png' %}"/></a>
                         </h3>
                         {% for o_region in region_list %}
                             {% if o_region.grouper == name %}
@@ -42,7 +42,7 @@
 			                              </a>
 			                              &nbsp;--&nbsp;
 			                              <a href="{% url delete_regionview regionview.pk %}" title="{% trans 'Delete' %}" onclick="return confirm('{%trans 'Delete this region view?'%}');">
-			                                <img src="{{ CYCLOPE_STATIC_URL}}images/delete.png" height="10px;"/>
+			                                <img src="{% static 'images/delete.png' %}" height="10px;"/>
 		                                  </a>
 		                              </li>
 			                        {% endfor %}

--- a/cyclope/templates/comments/list.html
+++ b/cyclope/templates/comments/list.html
@@ -5,7 +5,7 @@
 <ul class="media-list">{% endif %}
     <li id="c{{ comment.id }}" class="media">{# c## is used by the absolute URL of the Comment model, so keep that as it is. #}
         <div class="media-left" href="#">
-		<img class="media-object img-circle" src="{% static 'cyclope/images/img-author-not-available.png' %}" alt="Image not available">
+		<img class="media-object img-circle" src="{% static 'images/img-author-not-available.png' %}" alt="Image not available">
         </div>
         <div class="comment media-body">
             <h4 class="media-heading"> {% if comment.name %}{% trans 'By' %} {{ comment.name }}{% endif %}</h4>

--- a/cyclope/templates/cyclope/author_teaser.html
+++ b/cyclope/templates/cyclope/author_teaser.html
@@ -17,7 +17,7 @@
         {% else %}
         <div class="media-left">
             <a href="#">
-		    <img src="{% static 'cyclope/images/img-author-not-available.png' %}" class="img-circle"/>
+		    <img src="{% static 'images/img-author-not-available.png' %}" class="img-circle"/>
             </a>
         </div>
     {% endif %}

--- a/cyclope/templates/cyclope/themes/cyclope-bootstrap/base.html
+++ b/cyclope/templates/cyclope/themes/cyclope-bootstrap/base.html
@@ -8,7 +8,7 @@
 # (at your option) any later version.
  -->
 
-{% load layout i18n cyclope_utils compress %}
+{% load layout i18n cyclope_utils compress staticfiles %}
 
 {# TODO(sanhoerth): find best way to show lang-tag in mulitlang enviroment #}
 <html lang="es">
@@ -47,7 +47,7 @@
     {% endcompress %}
     <!-- /CSS -->
     <!--jquery needs to be here to work properly clear search box --> 
-    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}{{ CYCLOPE_JQUERY_PATH }}"></script>
+    <script type="text/javascript" src="{% static CYCLOPE_JQUERY_PATH %}"></script>
      
     {% block extra_head %}{% endblock %}
 
@@ -103,17 +103,17 @@
         <!-- Bootstrap core JavaScript
         ================================================== -->
         <!-- Placed at the end of the document so the pages load faster -->
-        <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/bootstrap/bootstrap.min.js"></script> 
-        <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/bootstrap/addons/jquery.smartmenus.js"></script>
-        <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/bootstrap/addons/jquery.smartmenus.bootstrap.js"></script>
+        <script type="text/javascript" src="{% static 'js/bootstrap/bootstrap.min.js' %}"></script> 
+        <script type="text/javascript" src="{% static 'js/bootstrap/addons/jquery.smartmenus.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/bootstrap/addons/jquery.smartmenus.bootstrap.js' %}"></script>
         {% if not COMPRESS_ENABLED %}
-            <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/less.min.js"></script>
+            <script type="text/javascript" src="{% static 'js/less.min.js' %}"></script>
         {% endif %}
         {% if CYCLOPE_SITE_SETTINGS.enable_ratings %}
-        <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/ratings.js" ></script>
+        <script type="text/javascript" src="{% static 'js/ratings.js' %}" ></script>
         {% endif %}
         <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-        <script src="{{ CYCLOPE_STATIC_URL }}js/ie10-viewport-bug-workaround.js"></script>
+        <script src="{% static 'js/ie10-viewport-bug-workaround.js' %}"></script>
     {% endcompress %}
 </body>
 </html>

--- a/cyclope/templates/filebrowser/index.html
+++ b/cyclope/templates/filebrowser/index.html
@@ -14,7 +14,7 @@
 {% block extrahead %}
     {{ block.super }}
     {% ifequal query.pop '1' %} <!-- FileBrowseField -->
-    <script language="javascript" type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}filebrowser/FB_FileBrowseField.js"></script>
+    <script language="javascript" type="text/javascript" src="{% static 'filebrowser/FB_FileBrowseField.js' %}"></script>
     {% endifequal %}
     {% ifequal query.pop '2' %} <!-- TinyMCE -->
     <script language="javascript" type="text/javascript" src="{{ settings_var.URL_TINYMCE }}tiny_mce_popup.js"></script>

--- a/cyclope/templates/rosetta/pofile.html
+++ b/cyclope/templates/rosetta/pofile.html
@@ -2,7 +2,7 @@
 {% load rosetta i18n staticfiles %}
 
 {% block extra_head %}
-<link rel="stylesheet" type="text/css" media="screen" href="{% static 'cyclope/css/admin_tools_theming.css' %}" />
+<link rel="stylesheet" type="text/css" media="screen" href="{% static 'css/admin_tools_theming.css' %}" />
 {% endblock %}
 
 {% block header %}

--- a/cyclope/templates/search/search.html
+++ b/cyclope/templates/search/search.html
@@ -1,11 +1,11 @@
 {% extends CYCLOPE_DEFAULT_TEMPLATE %}
-{% load i18n cyclope_utils crispy_forms_tags %}
+{% load i18n cyclope_utils crispy_forms_tags staticfiles %}
 
 {% block extra_head %}
     {% if CYCLOPE_SEARCH_DATE %}
-        <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}{{ CYCLOPE_JQUERY_UI_PATH }}"></script>
-	    <script type="text/javascript" src="{{ CYCLOPE_STATIC_URL }}js/datepicker-es.js"></script>
-        <link href="{{ CYCLOPE_STATIC_URL }}{{ CYCLOPE_JQUERY_UI_CSS_PATH }}" rel="stylesheet">
+        <script type="text/javascript" src="{% static CYCLOPE_JQUERY_UI_PATH %}"></script>
+	    <script type="text/javascript" src="{% static 'js/datepicker-es.js' %}"></script>
+        <link href="{% static CYCLOPE_JQUERY_UI_CSS_PATH %}" rel="stylesheet">
         <script type="text/javascript">
         $(function() {
 		{# TODO other locales, cyclope-wide setting #}

--- a/cyclope/widgets.py
+++ b/cyclope/widgets.py
@@ -58,9 +58,7 @@ class CKEditor(forms.Textarea):
     Widget providing CKEditor for Rich Text Editing.
     """
     class Media:
-        js = (
-            cyc_settings.CYCLOPE_STATIC_URL + 'ckeditor/ckeditor.js',
-        )
+        js = ('ckeditor/ckeditor.js', )
 
     def render(self, name, value, attrs={}):
         language = settings.LANGUAGE_CODE[:2]

--- a/demo/cyclope_project/media/admin
+++ b/demo/cyclope_project/media/admin
@@ -1,1 +1,0 @@
-/opt/cyclope_workenv/lib/python2.6/site-packages/django/contrib/admin/static/admin/

--- a/demo/cyclope_project/media/admin_tools
+++ b/demo/cyclope_project/media/admin_tools
@@ -1,1 +1,0 @@
-/opt/cyclope_workenv/lib/python2.6/site-packages/admin_tools/media/admin_tools

--- a/demo/cyclope_project/media/cyclope
+++ b/demo/cyclope_project/media/cyclope
@@ -1,1 +1,0 @@
-../../../cyclope/media

--- a/demo/cyclope_project/media/filebrowser
+++ b/demo/cyclope_project/media/filebrowser
@@ -1,1 +1,0 @@
-/opt/cyclope_workenv/lib/python2.6/site-packages/filebrowser/static/filebrowser

--- a/demo/cyclope_project/media/local_themes/custom_theme
+++ b/demo/cyclope_project/media/local_themes/custom_theme
@@ -1,1 +1,0 @@
-../../../../cyclope/media/themes/frecuency

--- a/demo/cyclope_project/media/markitup
+++ b/demo/cyclope_project/media/markitup
@@ -1,1 +1,0 @@
-/opt/cyclope_workenv/lib/python2.6/site-packages/markitup/static/markitup/

--- a/demo/cyclope_project/media/mptt_tree_editor
+++ b/demo/cyclope_project/media/mptt_tree_editor
@@ -1,1 +1,0 @@
-/opt/cyclope_workenv/lib/python2.6/site-packages/mptt_tree_editor/static/mptt_tree_editor/

--- a/demo/cyclope_project/templates/cyclope/themes/custom_theme
+++ b/demo/cyclope_project/templates/cyclope/themes/custom_theme
@@ -1,1 +1,0 @@
-../../../../../cyclope/templates/cyclope/themes/frecuency


### PR DESCRIPTION
removes the need for symbolic links in static/, hence removed from cyclopeproject command and demo site too
