### PR TITLE
Propuesta para resolver issue #112 de mal uso de mails a suscriptores para spam.

### DIFF
--- a/cyclope/apps/custom_comments/moderator.py
+++ b/cyclope/apps/custom_comments/moderator.py
@@ -20,8 +20,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.contrib.comments.moderation import CommentModerator, moderator
-
+from django.contrib.comments import signals
 import models
+from django.contrib.comments.models import CommentFlag
 
 class CustomCommentModerator(CommentModerator):
 
@@ -47,3 +48,10 @@ class CustomCommentModerator(CommentModerator):
             getattr(content_object, "allow_comments", True) != "NO":
             return True
         return False
+
+    def post_comment_approval(sender, **kwargs):
+        if kwargs['flag'].flag == CommentFlag.MODERATOR_APPROVAL:
+            kwargs['comment'].send_subscriptors_notifications()
+        
+    signals.comment_was_flagged.connect(post_comment_approval, sender=models.CustomComment)
+    

--- a/cyclope/apps/custom_comments/tests.py
+++ b/cyclope/apps/custom_comments/tests.py
@@ -33,7 +33,7 @@ class CustomCommentTest(TestCase):
         settings.MANAGERS = ('Manager', 'manager@test.org',)
         
     def test_suscribe(self):
-        self.set_moderation_setting(False)
+        custom_comment_models.moderation_enabled = lambda :False
         comment = self.create_comment()
         # mail sent to moderators only
         self.assertEqual(len(mail.outbox), 1)
@@ -49,17 +49,16 @@ class CustomCommentTest(TestCase):
 
     #MAIL
     def test_no_moderation_admin_mailed(self):
-        self.set_moderation_setting(False)
+        custom_comment_models.moderation_enabled = lambda :False
         comment = self.create_comment()
         self.assertEqual(len(mail.outbox), 1)
     
     def test_moderation_admin_mailed(self):
-        self.set_moderation_setting(True)
         comment = self.create_comment()
         self.assertEqual(len(mail.outbox), 1)
     
     def test_no_moderation_sucriptor_mails_sent(self): # FIXME not_sent
-        self.set_moderation_setting(False)
+        custom_comment_models.moderation_enabled = lambda :False
         comment = self.create_comment()
         self.assertEqual(len(mail.outbox), 1) # 1 to admin
         reply = CustomComment(
@@ -84,7 +83,6 @@ class CustomCommentTest(TestCase):
         self.assertEqual(len(mail.outbox), 5) # 3 to admin, 2 to suscriptor
         
     def test_moderation_suscriptor_mail_delayed(self):
-        self.set_moderation_setting(True)
         comment = self.create_comment()
         reply = CustomComment(
             name="Numerica", 
@@ -143,8 +141,3 @@ class CustomCommentTest(TestCase):
         comment.save()
         return comment
 
-    def set_moderation_setting(self, true_false):
-        site_settings = get_singleton(SiteSettings)
-        site_settings.moderate_comments = true_false
-        site_settings.save()
-#        SiteSettings._instance = None TODO invalidate cache

--- a/cyclope/apps/custom_comments/tests.py
+++ b/cyclope/apps/custom_comments/tests.py
@@ -18,6 +18,9 @@ from moderator import CustomCommentModerator, moderator
 
 moderator.register(Site, CustomCommentModerator)
 
+from cyclope.utils import get_singleton
+from cyclope.models import SiteSettings
+
 class CustomCommentTest(TestCase):
 
     fixtures = ['simplest_site.json']
@@ -28,23 +31,73 @@ class CustomCommentTest(TestCase):
         self.site.domain = "example.com"
         self.site.save()
         settings.MANAGERS = ('Manager', 'manager@test.org',)
-
+        
     def test_suscribe(self):
-        CustomComment.moderation_enabled = lambda x:True
+        self.set_moderation_setting(False)
         comment = self.create_comment()
         # mail sent to moderators only
         self.assertEqual(len(mail.outbox), 1)
         self.assertTrue("New comment posted on '%s'" % self.site in mail.outbox[0].subject)
-
         other_comment = self.create_comment()
 
         reply = CustomComment(name="SAn AE", email="san-ae@test.com", parent=comment,
                               content_object=self.site, site=self.site, subscribe=True)
         reply.save()
-
         # mail sent to moderators and to original author of first comment
-        self.assertEqual(len(mail.outbox), 4)
-        self.assertEqual(mail.outbox[3].to[0], "san@test.com")
+        self.assertEqual(len(mail.outbox), 4) # 2 admin-new, 1 reply-admin + 1 reply-suscriptor 
+        self.assertEqual(mail.outbox[3].to[0], "san@test.com") # reply-admin 
+
+    #MAIL
+    def test_no_moderation_admin_mailed(self):
+        self.set_moderation_setting(False)
+        comment = self.create_comment()
+        self.assertEqual(len(mail.outbox), 1)
+    
+    def test_moderation_admin_mailed(self):
+        self.set_moderation_setting(True)
+        comment = self.create_comment()
+        self.assertEqual(len(mail.outbox), 1)
+    
+    def test_no_moderation_sucriptor_mails_sent(self): # FIXME not_sent
+        self.set_moderation_setting(False)
+        comment = self.create_comment()
+        self.assertEqual(len(mail.outbox), 1) # 1 to admin
+        reply = CustomComment(
+            name="Numerica", 
+            email="webmaster@numerica.cl", 
+            parent=comment, 
+            content_object=self.site, 
+            site=self.site, 
+            subscribe=True
+        )
+        reply.save()
+        self.assertEqual(len(mail.outbox), 3) # 2 to admin, 1 to suscriptor
+        reply_2 = CustomComment(
+            name="Numerica", 
+            email="roberto@numerica.cl", 
+            parent=reply, 
+            content_object=self.site, 
+            site=self.site, 
+            subscribe=True
+        )
+        reply_2.save()
+        self.assertEqual(len(mail.outbox), 5) # 3 to admin, 2 to suscriptor
+        
+    def test_moderation_suscriptor_mail_delayed(self):
+        self.set_moderation_setting(True)
+        comment = self.create_comment()
+        reply = CustomComment(
+            name="Numerica", 
+            email="webmaster@numerica.cl", 
+            parent=comment, 
+            content_object=self.site, 
+            site=self.site, 
+            subscribe=True
+        )
+        reply.save()
+        self.assertEqual(len(mail.outbox), 2) # 2 to admin, 0 to suscriptor 
+    
+#  TODO  def test_moderation_suscriptor_mail_approved_sent
 
     def test_needs_moderation(self):
         custom_comment_models.moderation_enabled = lambda :False
@@ -90,3 +143,8 @@ class CustomCommentTest(TestCase):
         comment.save()
         return comment
 
+    def set_moderation_setting(self, true_false):
+        site_settings = get_singleton(SiteSettings)
+        site_settings.moderate_comments = true_false
+        site_settings.save()
+#        SiteSettings._instance = None TODO invalidate cache

--- a/cyclope/models.py
+++ b/cyclope/models.py
@@ -97,7 +97,7 @@ class SiteSettings(models.Model):
                                           ('NO',_('disabled'))
                                       ), default='YES')
     moderate_comments = models.BooleanField(_('moderate comments'),
-                                            default=False)
+                                            default=True)
     enable_comments_notifications = models.BooleanField(_('enable comments email notifications'),
                                                         default=True)
     enable_abuse_reports = models.BooleanField(_('enable abuse reports'), default=False)


### PR DESCRIPTION
Este pull request para resolver el issue #112 en que se hace mal uso del sistema de comentarios de Cyclope para enviar SPAM a los suscriptores de los comentarios.
Cyclope tiene una opción de suscribirse a los comentarios. Cuando uno la selecciona en un comentario, comienza a recibir correos cada vez que alguien más comenta en ese hilo. Esto es lo que está siendo mal utilizado.
Esta propuesta consiste en utilizar el sistema de moderación de comentarios de _Django_ para filtrarlos:

- Configurando Cyclope para **moderar por defecto** los comentarios (por defecto no se moderan actualmente).
- Cuando la moderación está **activada**:
    1. Se notifica solamente al _Administrador_ de un nuevo comentario. Este debe aprobarlo o rechazarlo.
    2. **Al ser aprobado el comentario**, se envian notificaciones a los suscriptores.
- Cuando la moderación no está activada:
  1. Se notifica al _Administrador_ y **se notifica a los suscriptores inmediatamente**. Esto tiene un [FIXME](https://github.com/Numerico/cyclope/blob/comment_notifications_moderation/cyclope/apps/custom_comments/tests.py#L61) pues mi opinión es que en este caso no se debiera notificar, pues es preferible que esto no suceda nunca a que se use para _spam_. 

Me gustaría que acordáramos este último punto antes de implementar esta solución.